### PR TITLE
Fix dirSelectable treeOption in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Attributes of angular treecontrol
 - `tree-model` : the tree data on the `$scope`. This can be an array of nodes or a single node.
 - `options` : different options to customize the tree control.
   - `nodeChildren` : the name of the property of each node that holds the node children. Defaults to 'children'.
-  - `dirSelection` : are directories (nodes with children) selectable? If not, clicking on the dir label will expand and contact the dir. Defaults to `true`.
+  - `dirSelectable` : are directories (nodes with children) selectable? If not, clicking on the dir label will expand and contact the dir. Defaults to `true`.
   - `equality` : the function used to determine equality between old nodes and new ones when checking whether a replacement node should be expanded and/or marked as selected. Defaults to a function which uses `angular.equals()` on everything except the property indicated in `nodeChildren`.
   - `isLeaf` : function (node) -> boolean used to determine if a node is a leaf or branch. The default function checks for existence of children of the node to determine leaf or branch.
   - `defaultExpanded` : array[node] - an array of nodes to be expanded in the tree by default


### PR DESCRIPTION
Just a minor tweak to the documentation: the actual treeOption for
specifying whether or not folders should expand/close when clicked
appears to be `dirSelectable` instead of `dirSelection`.

Thanks for this module! I've been looking for a decent-looking, fast
tree control for a few months now. :+1:
