### PR TITLE
Added support to prevent directory toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Attributes of angular treecontrol
 - `options` : different options to customize the tree control.
   - `nodeChildren` : the name of the property of each node that holds the node children. Defaults to 'children'.
   - `dirSelectable` : are directories (nodes with children) selectable? If not, clicking on the dir label will expand and contact the dir. Defaults to `true`.
+  - `dirToggleable` : function called before a node expands or collapses in the tree. The arguments are the toggled `node` and a boolean `expanding` (`true` for expansion, `false` for collapse). Defaults to `true` for all nodes.
   - `equality` : the function used to determine equality between old nodes and new ones when checking whether a replacement node should be expanded and/or marked as selected. Defaults to a function which uses `angular.equals()` on everything except the property indicated in `nodeChildren`.
   - `isLeaf` : function (node) -> boolean used to determine if a node is a leaf or branch. The default function checks for existence of children of the node to determine leaf or branch.
   - `injectClasses` : allows to inject additional CSS classes into the tree DOM

--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -53,6 +53,10 @@
                         return angular.equals(a, b);
                     }
 
+                    function defaultDirToggleable(){
+                        return true;
+                    }
+
                     $scope.options = $scope.options || {};
                     ensureDefault($scope.options, "nodeChildren", "children");
                     ensureDefault($scope.options, "dirSelectable", "true");
@@ -67,6 +71,7 @@
                     ensureDefault($scope.options.injectClasses, "labelSelected", "");
                     ensureDefault($scope.options, "equality", defaultEquality);
                     ensureDefault($scope.options, "isLeaf", defaultIsLeaf);
+                    ensureDefault($scope.options, "dirToggleable", defaultDirToggleable);
 
                     $scope.expandedNodes = $scope.expandedNodes || [];
                     $scope.expandedNodesMap = {};
@@ -102,6 +107,9 @@
 
                     $scope.selectNodeHead = function() {
                         var expanding = $scope.expandedNodesMap[this.$id] === undefined;
+                        if(!$scope.options.dirToggleable(this.node, expanding)){
+                            return;
+                        }
                         $scope.expandedNodesMap[this.$id] = (expanding ? this.node : undefined);
                         if (expanding) {
                             $scope.expandedNodes.push(this.node);


### PR DESCRIPTION
This adds another option to `$scope.options`: `dirToggleable`.

`dirToggleable` is a function that's passed two arguments: `node` and a boolean `expanding` indicating whether the node is going to be expanded or collapsed.

If the result of  `dirToggleable` is falsy, the action will terminate (return) and thus prevent toggling of the node/directory.
