### PR TITLE
Add Multiple Selection functionality. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Attributes of angular treecontrol
 - element content : the template to evaluate against each node (and the parent scope of the tree) for the node label.
 - `tree-model` : [Node|Array[Node]] the tree data on the `$scope`. This can be an array of nodes or a single node.
 - `selected-node` : [Node] binding for the selected node in the tree. Updating this value updates the selection displayed in the tree. Selecting a node in the tree will update this value.
+- `selected-nodes` : [Array[Node]] [Only used when multiSelectable option is true] binding for the selected nodes in the tree. Updating this value updates the nodes that are selected in the tree.
 - `expanded-nodes` : [Array[Node]] binding for the expanded nodes in the tree. Updating this value updates the nodes that are expanded in the tree.
 - `on-selection` : callback called whenever selecting a node in the tree. The callback argument is the selected node.
 - `on-toggle-select` : callback called whenever selecting or deselecting (in multi-select mode) a node in the tree. The callback argument is the clicked node and selected state.
@@ -116,7 +117,7 @@ Attributes of angular treecontrol
 - `options` : different options to customize the tree control.
   - `nodeChildren` : the name of the property of each node that holds the node children. Defaults to 'children'.
   - `dirSelectable` : are directories (nodes with children) selectable? If not, clicking on the dir label will expand and contact the dir. Defaults to `true`.
-  - `multiSelectable` : can select multiple items, with deselection on click of selected item. This changes the scope variable `selected-node` into a map of selected nodes.
+  - `multiSelectable` : can select multiple items, with deselection on click of selected item. If true then any value assigned to selected-node will be ignored and the selected-nodes attribute will be referenced instead.
   - `equality` : the function used to determine equality between old nodes and new ones when checking whether a replacement node should be expanded and/or marked as selected. Defaults to a function which uses `angular.equals()` on everything except the property indicated in `nodeChildren`.
   - `isLeaf` : function (node) -> boolean used to determine if a node is a leaf or branch. The default function checks for existence of children of the node to determine leaf or branch.
   - `injectClasses` : allows to inject additional CSS classes into the tree DOM

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ and add the data for the tree
 $scope.treeOptions = {
     nodeChildren: "children",
     dirSelectable: true,
+    multiSelectable: true,
     injectClasses: {
         ul: "a1",
         li: "a2",
@@ -114,6 +115,7 @@ Attributes of angular treecontrol
 - `options` : different options to customize the tree control.
   - `nodeChildren` : the name of the property of each node that holds the node children. Defaults to 'children'.
   - `dirSelectable` : are directories (nodes with children) selectable? If not, clicking on the dir label will expand and contact the dir. Defaults to `true`.
+  - `multiSelectable` : can select multiple items, with deselection on click of selected item. This changes the scope variable `selected-node` into a map of selected nodes.
   - `equality` : the function used to determine equality between old nodes and new ones when checking whether a replacement node should be expanded and/or marked as selected. Defaults to a function which uses `angular.equals()` on everything except the property indicated in `nodeChildren`.
   - `isLeaf` : function (node) -> boolean used to determine if a node is a leaf or branch. The default function checks for existence of children of the node to determine leaf or branch.
   - `injectClasses` : allows to inject additional CSS classes into the tree DOM

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Attributes of angular treecontrol
 - `selected-node` : [Node] binding for the selected node in the tree. Updating this value updates the selection displayed in the tree. Selecting a node in the tree will update this value.
 - `expanded-nodes` : [Array[Node]] binding for the expanded nodes in the tree. Updating this value updates the nodes that are expanded in the tree.
 - `on-selection` : callback called whenever selecting a node in the tree. The callback argument is the selected node.
+- `on-toggle-select` : callback called whenever selecting or deselecting (in multi-select mode) a node in the tree. The callback argument is the clicked node and selected state.
 - `on-node-toggle` : callback called whenever a node expands or collapses in the tree. The function arguments are the toggled node and a boolean which is true for expansion, false for collapse.
 - `options` : different options to customize the tree control.
   - `nodeChildren` : the name of the property of each node that holds the node children. Defaults to 'children'.

--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -32,6 +32,7 @@
                     selectedNode: "=?",
                     expandedNodes: "=?",
                     onSelection: "&",
+                    onToggleSelection: "&",
                     onNodeToggle: "&",
                     options: "=?",
                     orderBy: "@",
@@ -55,7 +56,7 @@
 
                     $scope.options = $scope.options || {};
                     ensureDefault($scope.options, "nodeChildren", "children");
-                    //ensureDefault($scope.options, "nodeId", "");
+                    //ensureDefault($scope.options, "nodeId", ""); // default to current scope.$id for clicked node
                     ensureDefault($scope.options, "dirSelectable", true);
                     ensureDefault($scope.options, "multiSelectable", false);
                     ensureDefault($scope.options, "injectClasses", {});
@@ -127,23 +128,24 @@
                             this.selectNodeHead();
                         }
                         else {
-
                             if ($scope.options.multiSelectable) {
+                                var selected = false;
                                 if (!$scope.selectedNode) {
                                     $scope.selectedNode = {};
                                 }
                                 var index =  ($scope.options.nodeId) ? clickedNode[$scope.options.nodeId] : this.$id;
                                 if ($scope.selectedNode[index] !== undefined) {
-                                    delete $scope.selectedNode[index]
+                                    delete $scope.selectedNode[index];
                                 }
                                 else {
+                                    selected = true;
                                     $scope.selectedNode[index] = clickedNode;
                                     if ($scope.onSelection) {
-                                        $scope.onSelection({node: clickedNode});
+                                        $scope.onSelection({node: clickedNode, selected: true});
                                     }
                                 }
-                                if ($scope.onSelection) {
-                                    $scope.onSelection({node: clickedNode});
+                                if ($scope.onToggleSelection) {
+                                    $scope.onToggleSelection({node: clickedNode, selected: selected});
                                 }
                             }
                             else
@@ -151,7 +153,7 @@
                                     if ($scope.selectedNode != clickedNode) {
                                         $scope.selectedNode = clickedNode;
                                         if ($scope.onSelection) {
-                                            $scope.onSelection({node: clickedNode});
+                                            $scope.onSelection({node: clickedNode, selected: true});
                                         }
                                     }
                                 }

--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -55,6 +55,7 @@
 
                     $scope.options = $scope.options || {};
                     ensureDefault($scope.options, "nodeChildren", "children");
+                    //ensureDefault($scope.options, "nodeId", "");
                     ensureDefault($scope.options, "dirSelectable", true);
                     ensureDefault($scope.options, "multiSelectable", false);
                     ensureDefault($scope.options, "injectClasses", {});
@@ -121,8 +122,8 @@
                             $scope.onNodeToggle({node: this.node, expanded: expanding});
                     };
 
-                    $scope.selectNodeLabel = function (selectedNode) {
-                        if (selectedNode[$scope.options.nodeChildren] && selectedNode[$scope.options.nodeChildren].length > 0 && !$scope.options.dirSelectable) {
+                    $scope.selectNodeLabel = function (clickedNode) {
+                        if (clickedNode[$scope.options.nodeChildren] && clickedNode[$scope.options.nodeChildren].length > 0 && !$scope.options.dirSelectable) {
                             this.selectNodeHead();
                         }
                         else {
@@ -131,32 +132,35 @@
                                 if (!$scope.selectedNode) {
                                     $scope.selectedNode = {};
                                 }
-                                if ($scope.selectedNode[this.$id] !== undefined) {
-                                    delete $scope.selectedNode[this.$id]
+                                var index =  ($scope.options.nodeId) ? clickedNode[$scope.options.nodeId] : this.$id;
+                                if ($scope.selectedNode[index] !== undefined) {
+                                    delete $scope.selectedNode[index]
                                 }
                                 else {
-                                    $scope.selectedNode[this.$id] = selectedNode;
+                                    $scope.selectedNode[index] = clickedNode;
                                     if ($scope.onSelection) {
-                                        $scope.onSelection({node: selectedNode});
+                                        $scope.onSelection({node: clickedNode});
                                     }
                                 }
                             }
                             else
                                 {
-                                    if ($scope.selectedNode != selectedNode) {
-                                        $scope.selectedNode = selectedNode;
+                                    if ($scope.selectedNode != clickedNode) {
+                                        $scope.selectedNode = clickedNode;
                                         if ($scope.onSelection) {
-                                            $scope.onSelection({node: selectedNode});
+                                            $scope.onSelection({node: clickedNode});
                                         }
                                     }
                                 }
                             }
                         };
 
-                        $scope.selectedClass = function () {
+                        $scope.selectedClass = function (node) {
+                            var index =  ($scope.options.multiSelectable && $scope.options.nodeId) ? node[$scope.options.nodeId] : this.$id;
+
                             var labelSelectionClass = classIfDefined($scope.options.injectClasses.labelSelected, false);
                             var injectSelectionClass = "";
-                            var isSelected = (($scope.options.multiSelectable && $scope.selectedNode && $scope.selectedNode[this.$id] != undefined ) || (!($scope.options.multiSelectable) && this.node === $scope.selectedNode));
+                            var isSelected = (($scope.options.multiSelectable && $scope.selectedNode && $scope.selectedNode[index] != undefined ) || (!($scope.options.multiSelectable) && this.node === $scope.selectedNode));
 
                             if (isSelected) {
                                 injectSelectionClass = "tree-selected";
@@ -173,7 +177,7 @@
                             '<li ng-repeat="node in node.' + $scope.options.nodeChildren + ' | orderBy:orderBy:reverseOrder" ng-class="headClass(node)" ' + classIfDefined($scope.options.injectClasses.li, true) + '>' +
                             '<i class="tree-branch-head" ng-class="iBranchClass()" ng-click="selectNodeHead(node)"></i>' +
                             '<i class="tree-leaf-head ' + classIfDefined($scope.options.injectClasses.iLeaf, false) + '"></i>' +
-                            '<div class="tree-label ' + classIfDefined($scope.options.injectClasses.label, false) + '" ng-class="selectedClass()" ng-click="selectNodeLabel(node)" tree-transclude></div>' +
+                            '<div class="tree-label ' + classIfDefined($scope.options.injectClasses.label, false) + '" ng-class="selectedClass(node)" ng-click="selectNodeLabel(node)" tree-transclude></div>' +
                             '<treeitem ng-if="nodeExpanded()"></treeitem>' +
                             '</li>' +
                             '</ul>';

--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -142,6 +142,9 @@
                                         $scope.onSelection({node: clickedNode});
                                     }
                                 }
+                                if ($scope.onSelection) {
+                                    $scope.onSelection({node: clickedNode});
+                                }
                             }
                             else
                                 {

--- a/demo/tree-control.html
+++ b/demo/tree-control.html
@@ -15,22 +15,22 @@
 <div ng-controller="Controller">
     <div style="display: flex; flex-direction: row">
         <div class="tree-border">
-            <h3>Classic Tree</h3>
-            <div>Selected: {{node1.label?node1.label:"N/A"}}</div>
+            <h3>Classic Tree : multi-select</h3>
+            <div>{{ node1 ? countSelected(node1) : 0 }} Nodes Selected</div>
             <treecontrol class="tree-classic" tree-model="treedata" options="opt1" on-selection="showSelected(node)" selected-node="node1">
                 label: {{node.label}} ({{node.id}})
             </treecontrol>
         </div>
         <div class="tree-border">
             <h3>Light Tree</h3>
-            <div>Selected: {{node2.label?node2.label:"N/A"}}</div>
+            <div>Selected: {{node2.label ? node2.label : "N/A"}}</div>
             <treecontrol class="tree-light" tree-model="treedata" options="opt2" on-selection="showSelected(node)" selected-node="node2">
                 label: {{node.label}} ({{node.id}})
             </treecontrol>
         </div>
         <div class="tree-border" style=" background: #555;">
             <h3 style="color: white">Dark Tree</h3>
-            <div style="color: white">Selected: {{node3.label?node3.label:"N/A"}}</div>
+            <div style="color: white">Selected: {{node3.label ? node3.label : "N/A"}}</div>
             <treecontrol class="tree-dark" tree-model="treedata" options="opt3" on-selection="showSelected(node)" selected-node="node3">
                 label: {{node.label}} ({{node.id}})  [{{label}}]
             </treecontrol>
@@ -67,6 +67,10 @@
                 $scope.selected = sel.label;
             };
 
+            $scope.countSelected = function(tree){
+                return Object.keys(tree).length;
+            };
+
             $scope.addRoot = function() {
                 $scope.treedata.push({ "label" : "New Node A", "id" : "id A", "children": [] });
             };
@@ -83,11 +87,13 @@
             $scope.opt1 = {
                 nodeChildren: "children",
                 dirSelectable: true,
-                multiSelectable: true
+                multiSelectable: true,
+                nodeId: "id"
             };
 
             $scope.opt2 = {
                 nodeChildren: "children",
+                nodeId: "id",
                 dirSelectable: false
             };
 

--- a/demo/tree-control.html
+++ b/demo/tree-control.html
@@ -82,7 +82,8 @@
 
             $scope.opt1 = {
                 nodeChildren: "children",
-                dirSelectable: true
+                dirSelectable: true,
+                multiSelectable: true
             };
 
             $scope.opt2 = {

--- a/test/angular-tree-control-test.js
+++ b/test/angular-tree-control-test.js
@@ -442,6 +442,48 @@ describe('treeControl', function() {
         });
     });
 
+    describe('onToggleSelection', function () {
+        var currentlySelectedCount = 0;
+
+        var countToggles = function (toggledNode, selected) {
+            if(selected){
+                currentlySelectedCount++;
+            }
+            else{
+                currentlySelectedCount--;
+            }
+        };
+
+        beforeEach(function () {
+            currentlySelectedCount = 0;
+            $rootScope.countToggles = countToggles;
+            $rootScope.treedata = createSubTree(2, 2);
+            $rootScope.treedata.push({});
+            $rootScope.treeOptions = {
+                multiSelectable: true
+            };
+
+            element = $compile('<treecontrol tree-model="treedata" options="treeOptions" on-toggle-selection="countToggles(node, selected)">{{node.label}}</treecontrol>')($rootScope);
+            $rootScope.$digest();
+        });
+
+        it('should increment currentlySelectedCount when a list item is clicked', function () {
+            element.find('li:eq(0) div').click();
+            expect(currentlySelectedCount).toBe(1);
+        });
+
+        it('should decrement currentlySelectedCount when a previously selected list item is clicked', function () {
+            element.find('li:eq(0) div').click();
+            expect(currentlySelectedCount).toBe(1);
+            element.find('li:eq(1) div').click();
+            expect(currentlySelectedCount).toBe(2);
+            element.find('li:eq(1) div').click();
+            expect(currentlySelectedCount).toBe(1);
+        });
+
+
+    });
+
     describe('expanded-nodes binding', function () {
         beforeEach(function () {
             $rootScope.treedata = createSubTree(3, 2);

--- a/test/angular-tree-control-test.js
+++ b/test/angular-tree-control-test.js
@@ -195,6 +195,7 @@ describe('treeControl', function() {
     });
 
     describe('selection', function() {
+
         it('should publish the currently selected node on scope', function () {
             $rootScope.treedata = createSubTree(2, 2);
             element = $compile('<treecontrol tree-model="treedata" selected-node="selectedItem">{{node.label}}</treecontrol>')($rootScope);
@@ -248,6 +249,37 @@ describe('treeControl', function() {
             $rootScope.$digest();
             expect(element.find('.tree-selected').length).toBe(1);
         });
+    });
+
+    describe('multi-selection', function() {
+
+        beforeEach(function() {
+            $rootScope.treedata = createSubTree(2, 2);
+            $rootScope.treeOptions = {
+                multiSelectable: true
+            };
+            $rootScope.selectedNodes ={};
+        });
+
+        it('should retain array of selected nodes', function() {
+            element = $compile('<treecontrol tree-model="treedata" options="treeOptions" selected-node="selectedNodes">{{node.label}}</treecontrol>')($rootScope);
+            $rootScope.$digest();
+
+
+            expect(Object.keys($rootScope.selectedNodes).length).toBe(0);
+
+            element.find('li:eq(0) div').click();
+            expect(element.find('.tree-selected').length).toBe(1);
+
+            expect(Object.keys($rootScope.selectedNodes).length).toBe(1);
+
+            element.find('li:eq(1) div').click();
+            expect(element.find('.tree-selected').length).toBe(2);
+
+            expect(Object.keys($rootScope.selectedNodes).length).toBe(2);
+
+        });
+
     });
 
     describe('options usage', function () {

--- a/test/angular-tree-control-test.js
+++ b/test/angular-tree-control-test.js
@@ -258,11 +258,11 @@ describe('treeControl', function() {
             $rootScope.treeOptions = {
                 multiSelectable: true
             };
-            $rootScope.selectedNodes ={};
+            $rootScope.selectedNodes = [];
         });
 
         it('should retain array of selected nodes', function() {
-            element = $compile('<treecontrol tree-model="treedata" options="treeOptions" selected-node="selectedNodes">{{node.label}}</treecontrol>')($rootScope);
+            element = $compile('<treecontrol tree-model="treedata" options="treeOptions" selected-nodes="selectedNodes">{{node.label}}</treecontrol>')($rootScope);
             $rootScope.$digest();
 
 


### PR DESCRIPTION
Hello,  We like your tree control, but we needed to be able to select multiple items and reference the selection set from the parent scope.  The change was simple; we were able to allow both modes (single/multi) without changing the exterior interface.  Much of the diff on the pull request is formatting changes imposed by intelliJ (sorry!).

We want to work on a second pull request that allows us to store the selected nodes map and reload from a user  preferences data from another browser.

We see that the $scope.$id for each tree node child scope created using ng-repeat is used to index the map of expandedNodes map. We used the same for the selectedNode(s) map.  We see that you can reload the tree with new data and keep the same selection (indexed by the child scope.$id)  Not sure how this will translate to persisting the selection set and re-configuring the tree on subsequent page refresh.  Any ideas ?