### PR TITLE
Support for angular 1.3.0

### DIFF
--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -154,9 +154,7 @@
                             '</li>' +
                             '</ul>';
 
-                    return {
-                        template: $compile(template)
-                    }
+                    this.template = $compile(template);
                 }],
                 compile: function(element, attrs, childTranscludeFn) {
                     return function ( scope, element, attrs, treemodelCntr ) {


### PR DESCRIPTION
In angular 1.3.0 there was a breaking change, the `return` in controllers won't work anymore (https://github.com/angular/angular.js/issues/8876).
This simple change will fix it.
