### PR TITLE
Add 'expandOnFilter' option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ and add the data for the tree
 $scope.treeOptions = {
     nodeChildren: "children",
     dirSelectable: true,
+    expandOnFilter: true,
     injectClasses: {
         ul: "a1",
         li: "a2",
@@ -114,6 +115,7 @@ Attributes of angular treecontrol
 - `options` : different options to customize the tree control.
   - `nodeChildren` : the name of the property of each node that holds the node children. Defaults to 'children'.
   - `dirSelectable` : are directories (nodes with children) selectable? If not, clicking on the dir label will expand and contact the dir. Defaults to `true`.
+  - `expandOnFilter` : when a filter is applied should we automatically expand the tree? Doing this makes it easier to see the filtered results. Defaults to `true`.
   - `equality` : the function used to determine equality between old nodes and new ones when checking whether a replacement node should be expanded and/or marked as selected. Defaults to a function which uses `angular.equals()` on everything except the property indicated in `nodeChildren`.
   - `isLeaf` : function (node) -> boolean used to determine if a node is a leaf or branch. The default function checks for existence of children of the node to determine leaf or branch.
   - `injectClasses` : allows to inject additional CSS classes into the tree DOM

--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -58,6 +58,7 @@
                     $scope.options = $scope.options || {};
                     ensureDefault($scope.options, "nodeChildren", "children");
                     ensureDefault($scope.options, "dirSelectable", "true");
+                    ensureDefault($scope.options, "expandOnFilter", "true");
                     ensureDefault($scope.options, "injectClasses", {});
                     ensureDefault($scope.options.injectClasses, "ul", "");
                     ensureDefault($scope.options.injectClasses, "li", "");
@@ -99,6 +100,9 @@
                     };
 
                     $scope.nodeExpanded = function() {
+                        if ($scope.options.expandOnFilter && !angular.isUndefined($scope.filterExpression) && angular.isString($scope.filterExpression) && $scope.filterExpression.length > 0) {
+                            return true;
+                        }
                         return !!$scope.expandedNodesMap[this.$id];
                     };
 


### PR DESCRIPTION
I've added an extra option to automatically expand the tree when a filter is applied, this makes it easier to see the results of the filter. This option has been setup with a default of 'true' and was added with minimal code.

Please note that I have also added to the read me markup to display and explain the new option as per the current format.