### PR TITLE
fixed: return in directive controllers not supported by angular 1.3

### DIFF
--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -159,9 +159,7 @@
                             '</li>' +
                             '</ul>';
 
-                    return {
-                        template: $compile(template)
-                    }
+                    this.template = $compile(template);
                 }],
                 compile: function(element, attrs, childTranscludeFn) {
                     return function ( scope, element, attrs, treemodelCntr ) {


### PR DESCRIPTION
Fixes: #60.
According to angular/angular.js#8876 we cannot use return in directive controllers anymore.