### PR TITLE
fixed default ordering when no order-by is supplied

### DIFF
--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -149,9 +149,10 @@
                     };
 
                     //tree template
+                    var orderBy = $scope.orderBy ? ' | orderBy:orderBy:reverseOrder' : '';
                     var template =
                         '<ul '+classIfDefined($scope.options.injectClasses.ul, true)+'>' +
-                            '<li ng-repeat="node in node.' + $scope.options.nodeChildren + ' | filter:filterExpression:filterComparator | orderBy:orderBy:reverseOrder" ng-class="headClass(node)" '+classIfDefined($scope.options.injectClasses.li, true)+'>' +
+                            '<li ng-repeat="node in node.' + $scope.options.nodeChildren + ' | filter:filterExpression:filterComparator ' + orderBy + '" ng-class="headClass(node)" '+classIfDefined($scope.options.injectClasses.li, true)+'>' +
                             '<i class="tree-branch-head" ng-class="iBranchClass()" ng-click="selectNodeHead(node)"></i>' +
                             '<i class="tree-leaf-head '+classIfDefined($scope.options.injectClasses.iLeaf, false)+'"></i>' +
                             '<div class="tree-label '+classIfDefined($scope.options.injectClasses.label, false)+'" ng-class="selectedClass()" ng-click="selectNodeLabel(node)" tree-transclude></div>' +

--- a/test/angular-tree-control-test.js
+++ b/test/angular-tree-control-test.js
@@ -263,6 +263,20 @@ describe('treeControl', function() {
 
     describe('options usage', function () {
 
+        it('should not reorder nodes if no order-by is provided', function() {
+            $rootScope.treedata = [
+                { label: "a", children: [] },
+                { label: "c", children: [] },
+                { label: "b", children: [] }
+            ];
+
+            element = $compile('<treecontrol tree-model="treedata" reverse-order="{{reverse}}">{{node.label}}</treecontrol>')($rootScope);
+            $rootScope.$digest();
+            expect(element.find('li:eq(0)').text()).toBe('a');
+            expect(element.find('li:eq(1)').text()).toBe('c');
+            expect(element.find('li:eq(2)').text()).toBe('b');
+        });
+
         it('should order sibling nodes in normal order', function() {
             $rootScope.treedata = [
                 { label: "a", children: [] },


### PR DESCRIPTION
wix/angular-tree-control#15 seemed to have broken the default
ordering of the tree. I think this fixes all the tests and restores the
ordering in the case that the user does not specify an orderBy
expression - that is, it does not change the tree order at all when
orderBy is not passed in, as one would expect.

Previously, the orderBy filter was blindly applied to the data, even
when the user didn't specify the orderBy attribute on the tree
control. Without this PR, the only way to order the tree is by passing
the orderBy attribute in the <tree-control> element. Programatic tree
ordering was ignored, since the orderBy filter of the directive itself
was always applied last. This is especially problematic since the
orderBy only accepts an expression and not a function, so there's no way
to customize the ordering further than passing in a property of your
nodes. For example, AngularJS's default orderBy is case insensitive, so
we don't have the option of ordering in a case sensitive fashion, unless
we create a completely separate property on the node purely for
ordering.

More importantly, if you did not provide an orderBy, the default orderBy
was being applied, and it did not understand the objects that we usually
use as nodes in our trees. Every user who does not provide an orderBy
will get unexpected ordering where angularJS tries to order objects
naively.