### PR TITLE
improve large tree performance in defaultEquality

### DIFF
--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -46,13 +46,11 @@
                     }
 
                     function defaultEquality(a, b) {
-                        if (a === undefined || b === undefined)
+                        if ( !a || !b ) {
                             return false;
-                        a = angular.copy(a);
-                        a[$scope.options.nodeChildren] = [];
-                        b = angular.copy(b);
-                        b[$scope.options.nodeChildren] = [];
-                        return angular.equals(a, b);
+                        }
+
+                        return a.$$hashKey == b.$$hashKey;
                     }
 
                     $scope.options = $scope.options || {};


### PR DESCRIPTION
This should fix #10 and fix #18, and should address performance issues on larger trees. On my test tree of 3000+ nodes, `defaultEquality` and `angular.copy` inside of it were the biggest loads on the CPU in the profiler. 

This was especially problematic since we were be making deep copies of the entire object and then throwing away the childrenNodes just to compare the parent - for a top level folder with many nested subfolders, we were doing a lot of work for little gain :(

Angular.copy was changed from 1.2 to 1.3 which may have contributed to this issue.

https://docs.angularjs.org/api/ng/function/angular.copy
https://docs.angularjs.org/guide/migration
https://github.com/angular/angular.js/commit/b59b04f98a0b59eead53f6a53391ce1bbcbe9b57

the code change was found in stidges's fork: https://github.com/stidges/angular-tree-control/blob/23bafaad7a58b76d581f1a02eda48e34e8100b98/angular-tree-control.js#L49