### PR TITLE
Support a custom filter for the repeat with arguments

### DIFF
--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -37,6 +37,7 @@
                     options: "=?",
                     orderBy: "@",
                     reverseOrder: "@",
+                    filter: "@",
                     filterExpression: "=?",
                     filterComparator: "=?"
                 },
@@ -197,10 +198,11 @@
                     };
 
                     //tree template
+                    var filter = $scope.filter ? $scope.filter : 'filter';
                     var orderBy = $scope.orderBy ? ' | orderBy:orderBy:reverseOrder' : '';
                     var template =
                         '<ul '+classIfDefined($scope.options.injectClasses.ul, true)+'>' +
-                            '<li ng-repeat="node in node.' + $scope.options.nodeChildren + ' | filter:filterExpression:filterComparator ' + orderBy + '" ng-class="headClass(node)" '+classIfDefined($scope.options.injectClasses.li, true)+'>' +
+                            '<li ng-repeat="node in node.' + $scope.options.nodeChildren + ' | ' + filter + ':filterExpression:filterComparator' + orderBy + '" ng-class="headClass(node)" '+classIfDefined($scope.options.injectClasses.li, true)+'>' +
                             '<i class="tree-branch-head" ng-class="iBranchClass()" ng-click="selectNodeHead(node)"></i>' +
                             '<i class="tree-leaf-head '+classIfDefined($scope.options.injectClasses.iLeaf, false)+'"></i>' +
                             '<div class="tree-label '+classIfDefined($scope.options.injectClasses.label, false)+'" ng-class="selectedClass()" ng-click="selectNodeLabel(node)" tree-transclude></div>' +

--- a/test/angular-tree-control-test.js
+++ b/test/angular-tree-control-test.js
@@ -2,6 +2,25 @@ describe('treeControl', function() {
     var $compile, $rootScope, element, num;
 
     beforeEach(function () {
+        angular.mock.module(function($filterProvider) {
+            $filterProvider.register('startsWithLetter', startsWithLetter);
+        });
+
+        // custom filter for the repeat with argument
+        function startsWithLetter() {
+            return function (items, letter) {
+                var filtered = [];
+                var letterMatch = new RegExp(letter, 'i');
+                for (var i = 0; i < items.length; i++) {
+                    var item = items[i];
+                    if (letterMatch.test(item.label.substring(0, 1))) {
+                        filtered.push(item);
+                    }
+                }
+                return filtered;
+            };
+        }
+
         module('treeControl');
         inject(function ($injector) {
             $compile = $injector.get('$compile');
@@ -523,6 +542,24 @@ describe('treeControl', function() {
             $rootScope.$digest();
             expect(element.find('li:eq(0)').text()).toBe('abcd');
             expect(element.find('li').length).toBe(1);
+        });
+
+        it('should be able to accept an alternative filter for the repeat with arguments', function() {
+            $rootScope.treedata = [
+                { label: "abcd", age: 12, children: [] },
+                { label: "abef", age: 12, children: [] },
+                { label: "bcde", age: 14, children: [] }
+            ];
+            $rootScope.predicate = "d";
+            element = $compile('<treecontrol tree-model="treedata" filter="startsWithLetter" filter-expression="predicate">{{node.label}}</treecontrol>')($rootScope);
+            $rootScope.$digest();
+            expect(element.find('li').length).toBe(0);
+
+            $rootScope.predicate = "a";
+            $rootScope.$digest();
+            expect(element.find('li:eq(0)').text()).toBe('abcd');
+            expect(element.find('li:eq(1)').text()).toBe('abef');
+            expect(element.find('li').length).toBe(2);
         });
     });
 


### PR DESCRIPTION
Added the option `filter` to be able to specify a custom filter for the repeat.

```html
<treecontrol class="tree-classic" tree-model="treedata" filter="myFilter" filter-expression="predicate" filter-comparator="comparator">
     label: {{node.label}} ({{node.id}})
 </treecontrol>
```
results in this filter `myFilter:filterExpression:filterComparator`, the local scope parameter `filterExpression` and `filterComparator` are reused.