### PR TITLE
use isLeaf function instead of hardcoded check when deciding to select h...

### DIFF
--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -158,8 +158,7 @@
                     };
 
                     $scope.selectNodeLabel = function( selectedNode ){
-                        if (selectedNode[$scope.options.nodeChildren] && selectedNode[$scope.options.nodeChildren].length > 0 &&
-                            !$scope.options.dirSelectable) {
+                        if(!$scope.options.isLeaf(selectedNode) && !$scope.options.dirSelectable) {
                             this.selectNodeHead();
                         }
                         else {


### PR DESCRIPTION
Fixes bug #73 

At the moment the logic to selectHead when dirSelectable = false is hardcoded. Pseudo code being:

(Is it a directory with children? AND is directory selectable false?)

We should really be using the isLeaf() function for the prior half.