### PR TITLE
Expanding all nodes in a large tree sometimes fails

### DIFF
--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -295,13 +295,22 @@
             return {
                 link: function(scope, element, attrs, controller) {
                     if (!scope.options.isLeaf(scope.node)) {
-                        angular.forEach(scope.expandedNodesMap, function (node, id) {
-                            if (scope.options.equality(node, scope.node)) {
-                                scope.expandedNodesMap[scope.$id] = scope.node;
-                                scope.expandedNodesMap['x'+id] = undefined;
+                        var exchangeNodesInMap = function (node, id) {
+                            scope.expandedNodesMap[scope.$id] = scope.node;
+                            scope.expandedNodesMap["x"+id] = undefined;
+                        };
+
+                        for(var key in scope.expandedNodesMap) {
+                            if (scope.expandedNodesMap.hasOwnProperty(key)) {
+                                var node = scope.expandedNodesMap[key];
+                                if (scope.options.equality(node, scope.node)) {
+                                    exchangeNodesInMap(node, key);
+                                    break;
+                                }
                             }
-                        });
-                    }
+                        }
+					}
+
                     if (!scope.options.multiSelection && scope.options.equality(scope.node, scope.selectedNode)) {
                         scope.selectedNode = scope.node;
                     } else if (scope.options.multiSelection) {

--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -95,7 +95,7 @@
                     $scope.expandedNodes = $scope.expandedNodes || [];
                     $scope.expandedNodesMap = {};
                     for (var i=0; i < $scope.expandedNodes.length; i++) {
-                        $scope.expandedNodesMap[""+i] = $scope.expandedNodes[i];
+                        $scope.expandedNodesMap['x'+i] = $scope.expandedNodes[i];
                     }
                     $scope.parentScopeOfTree = $scope.$parent;
 
@@ -258,7 +258,7 @@
                                     }
                                 }
                                 if (!found)
-                                    newExpandedNodesMap[notFoundIds++] = newExNode;
+                                    newExpandedNodesMap['x' + notFoundIds++] = newExNode;
                             });
                             scope.expandedNodesMap = newExpandedNodesMap;
                         });
@@ -298,7 +298,7 @@
                         angular.forEach(scope.expandedNodesMap, function (node, id) {
                             if (scope.options.equality(node, scope.node)) {
                                 scope.expandedNodesMap[scope.$id] = scope.node;
-                                scope.expandedNodesMap[id] = undefined;
+                                scope.expandedNodesMap['x'+id] = undefined;
                             }
                         });
                     }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-tree-control-djmatty",
-  "version": "0.2.9",
+  "version": "0.2.9.1",
   "main": [
     "./angular-tree-control.js",
     "./css/tree-control.css"

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular-tree-control",
+  "name": "angular-tree-control-djmatty",
   "version": "0.2.9",
   "main": [
     "./angular-tree-control.js",


### PR DESCRIPTION
I came across an issue with the expandedNodesMap when using the control with large trees, it seems that sometimes the scope ids clash with the index based node ids. I came across this when I was trying to expand the whole tree in code. Setting expandedNodes to an array of all the nodes would sometimes work, and sometimes it would just expand some of the nodes. The treeTransclude directive was setting valid scope ids to undefined because the index matched.

Changing the index based keys to be prefixed with 'x' prevents the clash and the tree expands properly every time.