### PR TITLE
add tree-label-container

### DIFF
--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -90,6 +90,7 @@
                     ensureDefault($scope.options.injectClasses, "labelSelected", "");
                     ensureDefault($scope.options, "equality", defaultEquality);
                     ensureDefault($scope.options, "isLeaf", defaultIsLeaf);
+                    ensureDefault($scope.options, "trackBy", 'id');
 
                     $scope.selectedNodes = $scope.selectedNodes || [];
                     $scope.expandedNodes = $scope.expandedNodes || [];
@@ -206,7 +207,7 @@
                     var orderBy = $scope.orderBy ? ' | orderBy:orderBy:reverseOrder' : '';
                     var template =
                       '<ul '+classIfDefined($scope.options.injectClasses.ul, true)+'>' +
-                          '<li ng-repeat="node in node.' + $scope.options.nodeChildren + ' | filter:filterExpression:filterComparator ' + orderBy + '" ng-class="headClass(node)" '+classIfDefined($scope.options.injectClasses.li, true)+'>' +
+                          '<li ng-repeat="node in node.' + $scope.options.nodeChildren + ' track by ' + $scope.options.trackBy + ' | filter:filterExpression:filterComparator ' + orderBy + '" ng-class="headClass(node)" '+classIfDefined($scope.options.injectClasses.li, true)+'>' +
                               '<div class="tree-label-container">' +
                                   '<i class="tree-branch-head" ng-class="iBranchClass()" ng-click="selectNodeHead(node)"></i>' +
                                   '<i class="tree-leaf-head '+classIfDefined($scope.options.injectClasses.iLeaf, false)+'"></i>' +

--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -1,6 +1,6 @@
 (function ( angular ) {
     'use strict';
-    
+
     angular.module( 'treeControl', [] )
         .directive( 'treecontrol', ['$compile', function( $compile ) {
             /**
@@ -17,12 +17,12 @@
                 else
                     return "";
             }
-            
+
             function ensureDefault(obj, prop, value) {
                 if (!obj.hasOwnProperty(prop))
                     obj[prop] = value;
             }
-            
+
             return {
                 restrict: 'EA',
                 require: "treecontrol",
@@ -205,14 +205,16 @@
                     //tree template
                     var orderBy = $scope.orderBy ? ' | orderBy:orderBy:reverseOrder' : '';
                     var template =
-                        '<ul '+classIfDefined($scope.options.injectClasses.ul, true)+'>' +
-                            '<li ng-repeat="node in node.' + $scope.options.nodeChildren + ' | filter:filterExpression:filterComparator ' + orderBy + '" ng-class="headClass(node)" '+classIfDefined($scope.options.injectClasses.li, true)+'>' +
-                            '<i class="tree-branch-head" ng-class="iBranchClass()" ng-click="selectNodeHead(node)"></i>' +
-                            '<i class="tree-leaf-head '+classIfDefined($scope.options.injectClasses.iLeaf, false)+'"></i>' +
-                            '<div class="tree-label '+classIfDefined($scope.options.injectClasses.label, false)+'" ng-class="selectedClass()" ng-click="selectNodeLabel(node)" tree-transclude></div>' +
-                            '<treeitem ng-if="nodeExpanded()"></treeitem>' +
-                            '</li>' +
-                            '</ul>';
+                      '<ul '+classIfDefined($scope.options.injectClasses.ul, true)+'>' +
+                          '<li ng-repeat="node in node.' + $scope.options.nodeChildren + ' | filter:filterExpression:filterComparator ' + orderBy + '" ng-class="headClass(node)" '+classIfDefined($scope.options.injectClasses.li, true)+'>' +
+                              '<div class="tree-label-container">' +
+                                  '<i class="tree-branch-head" ng-class="iBranchClass()" ng-click="selectNodeHead(node)"></i>' +
+                                  '<i class="tree-leaf-head '+classIfDefined($scope.options.injectClasses.iLeaf, false)+'"></i>' +
+                                  '<div class="tree-label '+classIfDefined($scope.options.injectClasses.label, false)+'" ng-class="selectedClass()" ng-click="selectNodeLabel(node)" tree-transclude></div>' +
+                              '</div>' +
+                              '<treeitem ng-if="nodeExpanded()"></treeitem>' +
+                          '</li>' +
+                      '</ul>';
 
                     this.template = $compile(template);
                 }],

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-tree-control",
-  "version": "0.2.9",
+  "version": "0.2.11",
   "main": [
     "./angular-tree-control.js",
     "./css/tree-control.css"

--- a/css/tree-control.css
+++ b/css/tree-control.css
@@ -107,3 +107,6 @@ treecontrol.tree-dark li .tree-selected {
 treecontrol.tree-dark {
     color: #ddd;
 }
+treecontrol.tree-label-container {
+  display: block;
+}


### PR DESCRIPTION
I had a requirement where part of my transcluded treeitem content had a floated right item (an options cog icon) and I wanted my label row to have a hover effect. I needed the label parts in a block element that I could target for my hover effect instead of the entire li.

tree-label-container let me target the label items but omit the content itself.