### PR TITLE
Support for Webpack + CommonJS Package Manager

### DIFF
--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -1,3 +1,7 @@
+/* commonjs package manager support (eg componentjs) */
+if (typeof module !== "undefined" && typeof exports !== "undefined" && module.exports === exports){
+  module.exports = 'treeControl';
+}
 (function ( angular ) {
     'use strict';
     

--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -157,7 +157,7 @@
                                     index = i;
                                 }
                             }
-                            if (index != undefined)
+                            if (index !== undefined)
                                 $scope.expandedNodes.splice(index, 1);
                         }
                         if ($scope.onNodeToggle) {
@@ -311,7 +311,7 @@
                         // we can fix this to work with the link transclude function with angular 1.2.6. as for angular 1.2.0 we need
                         // to keep using the compile function
                         scope.$treeTransclude = childTranscludeFn;
-                    }
+                    };
                 }
             };
         }])
@@ -322,7 +322,7 @@
                     $element.data('node', $scope.node);
                     $element.data('scope-id', $scope.$id);
                 }
-            }
+            };
         }])
         .directive("treeitem", function() {
             return {
@@ -334,7 +334,7 @@
                         element.html('').append(clone);
                     });
                 }
-            }
+            };
         })
         .directive("treeTransclude", function() {
             return {
@@ -378,6 +378,6 @@
                         element.append(clone);
                     });
                 }
-            }
+            };
         });
 })( angular );

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,10 @@
 {
   "name": "angular-tree-control",
   "version": "0.2.12",
+  "author": "Yoav Abrahami",
+  "contributors": [
+    "Benjamin Orozco <benoror@gmail.com>"
+  ],
   "main": [
     "./angular-tree-control.js",
     "./css/tree-control.css"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "type": "git",
     "url": "git://github.com/wix/angular-tree-control.git"
   },
-  "author": "",
+  "author": "Yoav Abrahami",
+  "contributors": [
+    "Benjamin Orozco <benoror@gmail.com>"
+  ],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/wix/angular-tree-control/issues"


### PR DESCRIPTION
### Motivation

Hi!

I'm in the process of refactoring an app to support modern JS tooling like Webpack & ES6.
A small change is needed to support CommonJS:

### Code Change

```
/* commonjs package manager support (eg componentjs) */
if (typeof module !== "undefined" && typeof exports !== "undefined" && module.exports === exports){
  module.exports = 'angular-md5';
}
```
**Source: [ui-router release](https://github.com/angular-ui/ui-router/blob/master/release/angular-ui-router.js#L9)*

### Working Examples

* https://github.com/gdi2290/angular-md5/issues/8
  * https://github.com/gdi2290/angular-md5/pull/9
* https://github.com/muratcorlu/angular-urlify/pull/1
* https://github.com/tarkanlar/Angular-Urlify/pull/1

### Sources

* [Using Angular 1.x With ES6 and Webpack by Jesus Rodriguez](http://angular-tips.com/blog/2015/06/using-angular-1-dot-x-with-es6-and-webpack/)
* [Webpack & Angular by Shawn McKay ](http://www.shmck.com/webpack-angular-part-3/)
* [Angular and Webpack for Modular Applications](https://egghead.io/series/angular-and-webpack-for-modular-applications) by @kentcdodds