### PR TITLE
Click $event is now available on node expansion and node selection for user functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Attributes of angular treecontrol
 - `selected-node` : [Node], used when `multiSelection=false`. Binding for the selected node in the tree. Updating this value updates the selection displayed in the tree. Selecting a node in the tree will update this value.
 - `selected-nodes` : [Array[Node]], used when `multiSelection=true`. Binding for the selected nodes in the tree. Updating this value updates the selection displayed in the tree. Selecting a node in the tree will update this value.
 - `expanded-nodes` : [Array[Node]] binding for the expanded nodes in the tree. Updating this value updates the nodes that are expanded in the tree.
-- `on-selection` : `(node, selected)` callback called whenever selecting a node in the tree. The callback expression can use the selected node (`node`) and a boolean which indicates if the node was selected or deselected (`selected`).
-- `on-node-toggle` : `(node, expanded)` callback called whenever a node expands or collapses in the tree. The callback expression can use the toggled node (`node`) and a boolean which indicates expansion or collapse (`expanded`).
+- `on-selection` : `(node, selected,$event)` callback called whenever selecting a node in the tree. The callback expression can use the selected node (`node`), a boolean which indicates if the node was selected or deselected (`selected`) and the mouse event generated from the selection (`$event`).
+- `on-node-toggle` : `(node, expanded, $event)` callback called whenever a node expands or collapses in the tree. The callback expression can use the toggled node (`node`), a boolean which indicates expansion or collapse (`expanded`) and the mouse event generated from the click (`$event`).
 - `options` : different options to customize the tree control.
   - `multiSelection` : [Boolean] enable multiple nodes selection in the tree.
   - `nodeChildren` : the name of the property of each node that holds the node children. Defaults to 'children'.

--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -150,7 +150,7 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
                         return !!$scope.expandedNodesMap[this.$id];
                     };
 
-                    $scope.selectNodeHead = function() {
+                    $scope.selectNodeHead = function(node,$event) {
                         var transcludedScope = this;
                         var expanding = $scope.expandedNodesMap[transcludedScope.$id] === undefined;
                         $scope.expandedNodesMap[transcludedScope.$id] = (expanding ? transcludedScope.node : undefined);
@@ -169,7 +169,7 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
                         }
                         if ($scope.onNodeToggle) {
                             var parentNode = (transcludedScope.$parent.node === transcludedScope.synteticRoot)?null:transcludedScope.$parent.node;
-                            $scope.onNodeToggle({node: transcludedScope.node, $event: transcludedScope.$event, $parentNode: parentNode,
+                            $scope.onNodeToggle({node: transcludedScope.node, $event: $event, $parentNode: parentNode,
                               $index: transcludedScope.$index, $first: transcludedScope.$first, $middle: transcludedScope.$middle,
                               $last: transcludedScope.$last, $odd: transcludedScope.$odd, $even: transcludedScope.$even, expanded: expanding});
 
@@ -180,7 +180,7 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
                         var transcludedScope = this;
                         if(!$scope.options.isLeaf(selectedNode) && (!$scope.options.dirSelectable || !$scope.options.isSelectable(selectedNode))) {
                             // Branch node is not selectable, expand
-                            this.selectNodeHead();
+                            this.selectNodeHead(selectedNode,$event);
                         }
                         else if($scope.options.isLeaf(selectedNode) && (!$scope.options.isSelectable(selectedNode))) {
                             // Leaf node is not selectable

--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -169,14 +169,14 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
                         }
                         if ($scope.onNodeToggle) {
                             var parentNode = (transcludedScope.$parent.node === transcludedScope.synteticRoot)?null:transcludedScope.$parent.node;
-                            $scope.onNodeToggle({node: transcludedScope.node, $parentNode: parentNode,
+                            $scope.onNodeToggle({node: transcludedScope.node, $event: transcludedScope.$event, $parentNode: parentNode,
                               $index: transcludedScope.$index, $first: transcludedScope.$first, $middle: transcludedScope.$middle,
                               $last: transcludedScope.$last, $odd: transcludedScope.$odd, $even: transcludedScope.$even, expanded: expanding});
 
                         }
                     };
 
-                    $scope.selectNodeLabel = function( selectedNode){
+                    $scope.selectNodeLabel = function( selectedNode, $event){
                         var transcludedScope = this;
                         if(!$scope.options.isLeaf(selectedNode) && (!$scope.options.dirSelectable || !$scope.options.isSelectable(selectedNode))) {
                             // Branch node is not selectable, expand
@@ -218,7 +218,7 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
                             }
                             if ($scope.onSelection) {
                                 var parentNode = (transcludedScope.$parent.node === transcludedScope.synteticRoot)?null:transcludedScope.$parent.node;
-                                $scope.onSelection({node: selectedNode, selected: selected, $parentNode: parentNode,
+                                $scope.onSelection({node: selectedNode, $event: $event, selected: selected, $parentNode: parentNode,
                                   $index: transcludedScope.$index, $first: transcludedScope.$first, $middle: transcludedScope.$middle,
                                   $last: transcludedScope.$last, $odd: transcludedScope.$odd, $even: transcludedScope.$even});
                             }
@@ -271,9 +271,9 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
                             '<ul {{options.ulClass}} >' +
                             '<li ng-repeat="node in node.{{options.nodeChildren}} | filter:filterExpression:filterComparator {{options.orderBy}}" ng-class="headClass(node)" {{options.liClass}}' +
                             'set-node-to-data>' +
-                            '<i class="tree-branch-head" ng-class="iBranchClass()" ng-click="selectNodeHead(node)"></i>' +
+                            '<i class="tree-branch-head" ng-class="iBranchClass()" ng-click="selectNodeHead(node,$event)"></i>' +
                             '<i class="tree-leaf-head {{options.iLeafClass}}"></i>' +
-                            '<div class="tree-label {{options.labelClass}}" ng-class="[selectedClass(), unselectableClass()]" ng-click="selectNodeLabel(node)" tree-transclude></div>' +
+                            '<div class="tree-label {{options.labelClass}}" ng-class="[selectedClass(), unselectableClass()]" ng-click="selectNodeLabel(node,$event)" tree-transclude></div>' +
                             '<treeitem ng-if="nodeExpanded()"></treeitem>' +
                             '</li>' +
                             '</ul>';


### PR DESCRIPTION
In one internal project I needed to know in the 'on-selection' callback I defined whether Shift key was pressed when the event happened. So, I forked angular-tree-control and added the needed code. As more people can find this new functionality useful, I'm sending this pull request.