### PR TITLE
Add option for expand/collapse directory if disabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Attributes of angular treecontrol
   - `multiSelection` : [Boolean] enable multiple nodes selection in the tree.
   - `nodeChildren` : the name of the property of each node that holds the node children. Defaults to 'children'.
   - `dirSelectable` : are directories (nodes with children) selectable? If not, clicking on the dir label will expand and contact the dir. Defaults to `true`.
+  - `dirExpandDisabled` : Should the functionality change for directories (nodes with children) to expand/collapse on click if they are disabled? Defaults to `true`.
   - `allowDeselect` : are nodes deselectable? If not, clicking on the label will not deselect node. Defaults to `true`.
   - `equality` : the function used to determine equality between old nodes and new ones when checking whether a replacement node should be expanded and/or marked as selected. Defaults to a function which uses `angular.equals()` on everything except the property indicated in `nodeChildren`.
   - `isLeaf` : function (node) -> boolean used to determine if a node is a leaf or branch. The default function checks for existence of children of the node to determine leaf or branch.

--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -66,6 +66,7 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
         ensureDefault($scope.options, "multiSelection", false);
         ensureDefault($scope.options, "nodeChildren", "children");
         ensureDefault($scope.options, "dirSelectable", "true");
+        ensureDefault($scope.options, "dirExpandDisabled", "true");
         ensureDefault($scope.options, "injectClasses", {});
         ensureDefault($scope.options.injectClasses, "ul", "");
         ensureDefault($scope.options.injectClasses, "li", "");
@@ -202,8 +203,10 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
                     $scope.selectNodeLabel = function( selectedNode){
                         var transcludedScope = this;
                         if(!$scope.options.isLeaf(selectedNode, $scope) && (!$scope.options.dirSelectable || !$scope.options.isSelectable(selectedNode))) {
-                            // Branch node is not selectable, expand
-                            this.selectNodeHead();
+                            if($scope.options.dirExpandDisabled) {
+                                // Branch node is not selectable, expand
+                                this.selectNodeHead();
+                            }
                         }
                         else if($scope.options.isLeaf(selectedNode, $scope) && (!$scope.options.isSelectable(selectedNode))) {
                             // Leaf node is not selectable


### PR DESCRIPTION
By default, this functionality is left on to preserve existing
functionality.

I would prefer if I had the option to not change the default
functionality such that clicking a node does not change from a
select/deselect action to expand/collapse if that node is a directory
that is disabled.
