### PR TITLE
A rocover fix for the deep circular object 'Maximum call stack size e…

### DIFF
--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -48,6 +48,7 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
 
         return dst || src;
     }
+
     function defaultEquality(a, b,$scope) {
         if (!a || !b)
             return false;
@@ -55,9 +56,16 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
         a[$scope.options.nodeChildren] = [];
         b = shallowCopy(b);
         b[$scope.options.nodeChildren] = [];
-        return angular.equals(a, b);
+        
+        var isEqual = false;
+        try{
+          isEqual = angular.equals(a, b);
+        }catch(ex){
+            console.warn(ex.message);
+        }
+        return isEqual;
     }
-
+    
     function defaultIsSelectable() {
         return true;
     }


### PR DESCRIPTION
This is an error rocovery fix for the deep circular object '_Maximum call stack size exceeded_' error for **angular.equals** in **defaultEquality** function.

In some cases with deep circular object it still gives error which is probably caused by the equivalence of two object in the shallow levels and more comparisons in the deep levels.